### PR TITLE
Rename default version from master to main

### DIFF
--- a/course/_versions.yml
+++ b/course/_versions.yml
@@ -1,1 +1,1 @@
-- version: master
+- version: main


### PR DESCRIPTION
Since we've renamed the `master` branch on the `course` repo to `main`, I believe this change is also needed here