### PR TITLE
Update timm _versions.yml

### DIFF
--- a/timm/_versions.yml
+++ b/timm/_versions.yml
@@ -1,2 +1,1 @@
-- version: master
-- version: v0.6.12
+- version: main


### PR DESCRIPTION
We want to deploy `main` instead of `master` now. Also removing tagged version that got pushed up on accident. 